### PR TITLE
Find token source from the discovered tokens set

### DIFF
--- a/caeora.mjs
+++ b/caeora.mjs
@@ -55,8 +55,10 @@ function replaceActorArtwork(actor, data, options, userId) {
 	if ( !replaceArtwork || (actor.type !== "npc") || !hasProperty(actor, "data.data.details.cr") ) return;
 	const cleanName = actor.name.replace(/ /g, "");
 	const crDir = String(getProperty(actor, "data.data.details.cr")).replace(".", "-");
-	const tokenSrc = `${TOKEN_PATH}cr${crDir}/with-shadows/${cleanName}.webp`;
-	if ( !availableTokens.has(tokenSrc) ) return;
+    // Find the token source in the available tokens.
+    // Using this method instead of hardcoding paths will work with The Bazaar as well as self-hosted Foundry
+    const tokenSrc = availableTokens.find(url => url.endsWith(`cr${crDir}/with-shadows/${cleanName}.webp`))
+    if (!tokenSrc) return;
 	actor.data.update({"img": tokenSrc, "data.token": actor.token || {}, "token.img": tokenSrc})
 }
 


### PR DESCRIPTION
Instead of constructing the url and checking that it exists in the set of available tokens, we instead look for the url which ends with the right filename in the available tokens.
Token image replacement will now work whether the module is installed in a self-hosted Foundry, or from the Forge's Bazaar, or in a user's assets library as a custom module with modified images

This fixes #13 and obsoletes #16 (at least part of it)